### PR TITLE
feat: 1-create-releasenote-and-github-container-registry-publish-workflow

### DIFF
--- a/.github/workflows/ghcr_publish.yaml
+++ b/.github/workflows/ghcr_publish.yaml
@@ -1,0 +1,40 @@
+name: Publish Docker image to GHCR
+
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        run: echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ github.sha }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,92 @@
+name: Release Bookify Server
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'  
+    branches:
+      - main  
+
+env:
+  DOCKER_IMAGE: ghcr.io/${{ github.repository_owner }}/bookify-serverside 
+  VERSION: ${{ github.ref_name }}
+
+
+permissions:
+  contents: write
+  pull-requests: read  
+  packages: write
+  security-events: write
+
+jobs:
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    environment: production
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          install: true
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_PAT }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.DOCKER_IMAGE }}
+          tags: |
+            type=raw,value=${{ env.VERSION }}
+            type=raw,value=latest
+
+      - name: Generate Changelog
+        uses: mikepenz/release-changelog-builder-action@v3
+        id: changelog
+        with:
+          configuration: |
+            template: |
+              ## Changes
+              {{#each releases}}
+                {{#if @first}}
+                  {{#each merges}}
+                    - {{message}} ({{id}})
+                  {{/each}}
+                  {{#each commits}}
+                    - {{subject}} ({{id}})
+                  {{/each}}
+                {{/if}}
+              {{/each}}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: Bookify Server ${{ env.VERSION }}
+          tag_name: ${{ env.VERSION }}
+          body: ${{ steps.changelog.outputs.changelog }}
+          draft: false
+          prerelease: false
+          generate_release_notes: true
+          # files: |
+          #   dist/*
+          #   docker-compose.prod.yml
+
+      # - name: Notify Slack
+      #   if: always()
+      #   uses: rtCamp/action-slack-notify@v2
+      #   env:
+      #     SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+      #     SLACK_COLOR: ${{ job.status == 'success' && '#36a64f' || '#ff0000' }}
+      #     SLACK_TITLE: 'Bookify Server ${{ env.VERSION }} ${{ job.status == 'success' && 'deployed successfully!' || 'deployment failed!' }}'
+      #     SLACK_MESSAGE: 'Release: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ env.VERSION }}'


### PR DESCRIPTION
# Create Release Note and GitHub Container Registry Publish Workflow

## Overview
Develop a **GitHub Actions workflow** to automate the generation of release notes and publishing of container images to the **GitHub Container Registry (GHCR)**.  
This will standardize versioning, improve release transparency, and streamline the CI/CD delivery pipeline.

## Objectives
- Implement automated **semantic versioning** based on commit history or tags.  
- Generate structured **release notes** summarizing features, fixes, and changes.  
- Build and publish Docker images to **GitHub Container Registry (ghcr.io)**.  
- Ensure workflow is triggered on **tag creation** or **release events**.  
- Integrate version metadata into the Docker image labels for traceability.

## Deliverables
- `.github/workflows/release.yml` with automated build, versioning, and release publishing.  
- Template for consistent and readable **release notes**.  
- GHCR configuration with proper authentication and repository permissions.  
- Documentation outlining release and rollback processes.

## Success Criteria
- Successful creation of versioned releases with auto-generated notes.  
- Container images are published to GHCR with semantic version tags (e.g., `v1.0.0`, `latest`).  
- Workflow executes automatically upon tagging or merging to the main branch.  
- End-to-end traceability between release notes, image versions, and commits.
